### PR TITLE
Accent Issues

### DIFF
--- a/code-templates/preconfig/configGlobalUser.yml
+++ b/code-templates/preconfig/configGlobalUser.yml
@@ -6,6 +6,7 @@ steps:
       script: |
         git config --global user.email $(GIT_USER_NAME)
         git config --global user.name $(GIT_USER_EMAIL)
+        git config core.quotepath off
         echo "Queued by: $(Build.QueuedBy)"
         echo "Queued by Id: $(Build.QueuedById)"
       workingDirectory: $(Pipeline.Workspace)/$(PATH_SALESFORCE)


### PR DESCRIPTION
Disable git config core.quotepath off in order to avoid accents on merger execution.